### PR TITLE
添加全站点评 RSS 订阅 & 小问题修复

### DIFF
--- a/app/templates/feed.xml
+++ b/app/templates/feed.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<rss version="2.0">
+<channel>
+  <title>USTC 评课社区 - 全站最新点评</title>
+  <link>https://icourse.club</link>
+  <description>评课是为了更好地选课！</description>
+  {% for review in reviews.items %}
+    {% if not review.is_hidden %}
+    <item>
+        <title>{{ review.author.username }} 点评了 {{ review.course.name }}{% if review.course.teachers %}（{{ review.course.teacher_names_display }}）{% endif %}</title>
+        <link>{{ url_for('course.view_course', course_id=review.course.id) }}#review-{{ review.id }}</link>
+        <description>{{ review.content|abstract }}<a href="{{ url_for('course.view_course', course_id=review.course.id) }}#review-{{ review.id }}">&gt;&gt;更多</a></description>
+    </item>
+    {% endif %}
+  {% endfor %}
+</channel>
+</rss>

--- a/app/templates/feed.xml
+++ b/app/templates/feed.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" ?>
 <rss version="2.0">
 <channel>
   <title>USTC 评课社区 - 全站最新点评</title>
@@ -8,8 +8,8 @@
     {% if not review.is_hidden %}
     <item>
         <title>{{ review.author.username }} 点评了 {{ review.course.name }}{% if review.course.teachers %}（{{ review.course.teacher_names_display }}）{% endif %}</title>
-        <link>{{ url_for('course.view_course', course_id=review.course.id) }}#review-{{ review.id }}</link>
-        <description>{{ review.content|abstract }}<a href="{{ url_for('course.view_course', course_id=review.course.id) }}#review-{{ review.id }}">&gt;&gt;更多</a></description>
+        <link>https://icourse.club/{{ url_for('course.view_course', course_id=review.course.id) }}#review-{{ review.id }}</link>
+        <description>{{ review.content|abstract }}</description>
     </item>
     {% endif %}
   {% endfor %}

--- a/app/views/home.py
+++ b/app/views/home.py
@@ -1,4 +1,4 @@
-from flask import Blueprint,request, redirect,url_for,render_template,flash, abort, jsonify
+from flask import Blueprint, request, redirect, url_for, render_template, flash, abort, jsonify, make_response
 from flask_login import login_user, login_required, current_user, logout_user
 from app.models import User, RevokedToken as RT, Course, CourseRate, Teacher, Review, Notification
 from app.forms import LoginForm, RegisterForm, ForgotPasswordForm, ResetPasswordForm
@@ -26,7 +26,10 @@ def latest_reviews():
 @home.route('/feed.xml')
 def latest_reviews_rss():
     reviews_paged = Review.query.order_by(Review.id.desc()).paginate(page=1, per_page=50)
-    return render_template('feed.xml', reviews=reviews_paged)
+    rss_content = render_template('feed.xml', reviews=reviews_paged)
+    response = make_response(rss_content)
+    response.headers['Content-Type'] = 'application/rss+xml'
+    return response
 
 @home.route('/follow_reviews')
 def follow_reviews():

--- a/app/views/home.py
+++ b/app/views/home.py
@@ -23,6 +23,11 @@ def latest_reviews():
     reviews_paged = Review.query.order_by(Review.id.desc()).paginate(page=page, per_page=per_page)
     return render_template('latest-reviews.html', reviews=reviews_paged, title='全站最新点评', this_module='home.latest_reviews')
 
+@home.route('/feed.xml')
+def latest_reviews_rss():
+    reviews_paged = Review.query.order_by(Review.id.desc()).paginate(page=1, per_page=50)
+    return render_template('feed.xml', reviews=reviews_paged)
+
 @home.route('/follow_reviews')
 def follow_reviews():
     if not current_user.is_authenticated:

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ pytz
 # don't know why these dependencies fail...
 click
 wtforms
+pillow


### PR DESCRIPTION
这个 PR 尝试添加 `/feed.xml` 这个路由来提供全站点评的 RSS 订阅。因为我自己有时候会看首页全站的点评（很有意思），想着要是能直接用 RSS 阅读器就更方便了。

另外修复了 `requirements.txt` 中缺少 PIL (pillow) 依赖的问题。

（PS：要是仓库里有测试数据或者直接有现成的测试数据生成器就方便多了）